### PR TITLE
feat: context menu transparency via DWM

### DIFF
--- a/w11-theming-suite.psd1
+++ b/w11-theming-suite.psd1
@@ -45,6 +45,8 @@
         'Invoke-StartMenuTransparency',
         'Invoke-ActionCenterDiscovery',
         'Invoke-ActionCenterTransparency',
+        'Set-W11ContextMenuBackdrop',
+        'Get-W11ContextMenuBackdropStatus',
         'Start-W11BackdropWatcher',
         'Stop-W11BackdropWatcher',
         'Register-W11BackdropWatcherStartup',

--- a/w11-theming-suite.psm1
+++ b/w11-theming-suite.psm1
@@ -89,6 +89,9 @@ Export-ModuleMember -Function @(
     # NativeTaskbarTransparency (Action Center + Notifications)
     'Invoke-ActionCenterDiscovery',
     'Invoke-ActionCenterTransparency',
+    # NativeTaskbarTransparency (Context Menu transparency)
+    'Set-W11ContextMenuBackdrop',
+    'Get-W11ContextMenuBackdropStatus',
     # NativeTaskbarTransparency (Backdrop Watcher)
     'Start-W11BackdropWatcher',
     'Stop-W11BackdropWatcher',


### PR DESCRIPTION
## Summary
- Add `Set-W11ContextMenuBackdrop` for one-shot DWM backdrop on visible context menus and XAML popups
- Add `Get-W11ContextMenuBackdropStatus` for reporting watcher status and menu styling count
- Enhance BackdropWatcher with `EVENT_SYSTEM_MENUPOPUPSTART` (0x0006) hook for more reliable menu detection
- Add `FindWindowsByClass` C# helper for enumerating windows by class name
- Separate `MenuAppliedCount` tracking for context menus (transient, not cached)

## Changes
- `modules/NativeTaskbarTransparency/NativeTaskbarTransparency.psm1` - C# enhancements + 2 new PS functions
- `w11-theming-suite.psm1` - updated exports
- `w11-theming-suite.psd1` - updated FunctionsToExport

## Test plan
- [x] Module loads without errors (48 total commands)
- [x] Both new commands available via Get-Command
- [ ] `Set-W11ContextMenuBackdrop` applies backdrop to open context menus
- [ ] `Start-W11BackdropWatcher -IncludeContextMenus` auto-styles new menus
- [ ] `Get-W11ContextMenuBackdropStatus` reports correct counts

Closes #7